### PR TITLE
DVB-C UPC CZ: Added more muxes and changed QAM/256 on 626 MHz mux

### DIFF
--- a/dvb-c/cz-UPC
+++ b/dvb-c/cz-UPC
@@ -1,6 +1,14 @@
 # UPC Česká republika | https://www.upc.cz/
-# Created from http://www.upczone.cz/download/seznam_muxu.htm
-# Last updated: 15/10/2016
+# Created from https://www.upc.cz/content/dam/www-upc-cz/pdf/2017/prog_2017_razeni_CZ.xlsx.pdf
+# Last updated: 31/10/2017
+
+[CHANNEL]
+	DELIVERY_SYSTEM = DVBC/ANNEX_A
+	FREQUENCY = 546000000
+	SYMBOL_RATE = 6900000
+	INNER_FEC = 3/5
+	MODULATION = QAM/256
+	INVERSION = AUTO  
 
 [CHANNEL]
 	DELIVERY_SYSTEM = DVBC/ANNEX_A
@@ -41,6 +49,14 @@
 	INNER_FEC = 3/5
 	MODULATION = QAM/256
 	INVERSION = AUTO
+  
+[CHANNEL]
+	DELIVERY_SYSTEM = DVBC/ANNEX_A
+	FREQUENCY = 594000000
+	SYMBOL_RATE = 6900000
+	INNER_FEC = 3/5
+	MODULATION = QAM/256
+	INVERSION = AUTO  
 
 [CHANNEL]
 	DELIVERY_SYSTEM = DVBC/ANNEX_A
@@ -71,7 +87,7 @@
 	FREQUENCY = 626000000
 	SYMBOL_RATE = 6900000
 	INNER_FEC = 3/5
-	MODULATION = QAM/64
+	MODULATION = QAM/256
 	INVERSION = AUTO
 
 [CHANNEL]


### PR DESCRIPTION
They recently changed QAM to 256 (from 64) on 626 MHz
Source: https://www.upczone.cz/topic/5650-nov%C3%A9-stanice/?do=findComment&comment=98118
Otherwise scan ends up wit result: FAILED