### PR TITLE
rename Sonera to Telia, add 2 missing muxes

### DIFF
--- a/dvb-c/fi-Telia
+++ b/dvb-c/fi-Telia
@@ -1,7 +1,7 @@
-# Sonera kaapeli-tv (Finland)
-# Maksuttomat kanavat ovat 242,250,314,370 ja 410 MHz:n muxeissa
-#
-# freq      sr      fec  mod
+# Telia (ent. Sonera) kaapeli-tv (Finland)
+# Maksuttomat kanavat ovat 242, 250, 314, 370 ja 410 MHz:n muxeissa
+# Source: https://www.telia.fi/asiakastuki/tv-ja-viihde/telia-tv-kanavapaikat#kaapeli-tv-taajuudet
+
 [CHANNEL]
 	DELIVERY_SYSTEM = DVBC/ANNEX_A
 	FREQUENCY = 234000000
@@ -188,9 +188,24 @@
 
 [CHANNEL]
 	DELIVERY_SYSTEM = DVBC/ANNEX_A
-	FREQUENCY = 330000000
+	FREQUENCY = 282000000
 	SYMBOL_RATE = 6900000
 	INNER_FEC = AUTO
 	MODULATION = QAM/256
 	INVERSION = AUTO
 
+[CHANNEL]
+	DELIVERY_SYSTEM = DVBC/ANNEX_A
+	FREQUENCY = 290000000
+	SYMBOL_RATE = 6900000
+	INNER_FEC = AUTO
+	MODULATION = QAM/256
+	INVERSION = AUTO
+
+[CHANNEL]
+	DELIVERY_SYSTEM = DVBC/ANNEX_A
+	FREQUENCY = 330000000
+	SYMBOL_RATE = 6900000
+	INNER_FEC = AUTO
+	MODULATION = QAM/256
+	INVERSION = AUTO


### PR DESCRIPTION
Renamed Sonera to Telia because the previous company called Sonera no longer exists after a company merger (since 2017)

Also added a couple of missing muxes and confirmed against the company provided frequency listing that all other data entries are valid as they were