### PR TITLE
Update scan tables fr-Paris

### DIFF
--- a/dvb-t/fr-Paris
+++ b/dvb-t/fr-Paris
@@ -1,13 +1,14 @@
 # en : Paris - France - various DVB-T transmitters
 # fr : Paris - France - differents emetteurs DVB-T de la Tour Eiffel
-# Latest update for the data / derniere mise a jour des donnees : 2017-01-01
+# Latest update for the data / derniere mise a jour des donnees : 2025-10-10
 #
-# City                   Multiplex number : R1 R2 R3 R4 R6 R7 R15
-# Paris - Eiffel Tower - Channel number   : 35 25 22 30 32 42 28
+# City                   Multiplex number : R1 R2 R4 R6 R7 R15
+# Paris - Eiffel Tower - Channel number   : 35 25 30 32 42 28
 #
 # Note :
 # R8 - Is no longer used since the 05/04/2016 - Channel 58 is no longer used
 # R5 - Is no longer used since the 05/04/2016 - Channel 28 Re-assigned for R15
+# R3 - Is no longer used since the 06/06/2025 - Channel 22 is no longer used
 #
 
 # R1 - Channel/Canal 35 -  Groupe GR1 A (France 2 HD, France 4 HD, France Ô SD, franceinfo: SD), Groupe GR 1 (France 3-Paris Ile de France), Groupe R1 TFL (BFM Business Paris HD)
@@ -27,19 +28,6 @@
 [CHANNEL 25]
 	DELIVERY_SYSTEM = DVBT
 	FREQUENCY = 506166000
-	BANDWIDTH_HZ = 8000000
-	CODE_RATE_HP = 2/3
-	CODE_RATE_LP = NONE
-	MODULATION = QAM/64
-	TRANSMISSION_MODE = 8K
-	GUARD_INTERVAL = 1/32
-	HIERARCHY = NONE
-	INVERSION = AUTO
-
-# R3 - Channel/Canal 22 - Groupe CNH (Canal+, Canal+ Cinema, Canal+ Sport, Planete+, LCI, Paris Premiere, ?, ?, ?, DATASYSTEM R7, ?)
-[CHANNEL 22]
-	DELIVERY_SYSTEM = DVBT
-	FREQUENCY = 482166000
 	BANDWIDTH_HZ = 8000000
 	CODE_RATE_HP = 2/3
 	CODE_RATE_LP = NONE

--- a/dvb-t/fr-Paris
+++ b/dvb-t/fr-Paris
@@ -11,7 +11,7 @@
 # R3 - Is no longer used since the 06/06/2025 - Channel 22 is no longer used
 #
 
-# R1 - Channel/Canal 35 -  Groupe GR1 A (France 2 HD, France 4 HD, France Ô SD, franceinfo: SD), Groupe GR 1 (France 3-Paris Ile de France), Groupe R1 TFL (BFM Business Paris HD)
+# R1 - Channel/Canal 35 -  Groupe GR1 A (France 2, France 4, franceinfo:), Groupe GR 1 (France 3-Paris Ile de France)
 [CHANNEL 35]
 	DELIVERY_SYSTEM = DVBT
 	FREQUENCY = 586166000
@@ -24,7 +24,7 @@
 	HIERARCHY = NONE
 	INVERSION = AUTO
 
-# R2 - Channel/Canal 25 - Groupe NTN (C8, BFM TV, I-Tele, CStar, Gulli)
+# R2 - Channel/Canal 25 - Groupe NTN (BFM TV, CNEWS, CSTAR, Gulli, T18, NOVO19)
 [CHANNEL 25]
 	DELIVERY_SYSTEM = DVBT
 	FREQUENCY = 506166000
@@ -37,7 +37,7 @@
 	HIERARCHY = NONE
 	INVERSION = AUTO
 
-# R4 - Channel/Canal 30 - Groupe Multi4 (M6, W9, Arte, France5, 6ter)
+# R4 - Channel/Canal 30 - Groupe Multi4 (M6, W9, Arte, France5, 6ter, PARIS PREMIERE)
 [CHANNEL 30]
 	DELIVERY_SYSTEM = DVBT
 	FREQUENCY = 546166000
@@ -50,7 +50,7 @@
 	HIERARCHY = NONE
 	INVERSION = AUTO
 
-# R6 - Channel/Canal 32 - Groupe SMR6 (TF1, NRJ12, TMC, NT1, LCP-Public Senat)
+# R6 - Channel/Canal 32 - Groupe SMR6 (TF1, TMC, TFX, LCP, LCI)
 [CHANNEL 32]
 	DELIVERY_SYSTEM = DVBT
 	FREQUENCY = 562166000
@@ -63,7 +63,7 @@
 	HIERARCHY = NONE
 	INVERSION = AUTO
 
-# R7 - Channel/Canal 42 - Groupe MHD7 (HD1, Cherie 25, L equipe 21, RMC Decouverte, Numero 23)
+# R7 - Channel/Canal 42 - Groupe MHD7 (TF1 Séries Films, L'Equipe 21, RMC LIFE, RMC Découverte, RMC Story)
 [CHANNEL 42]
 	DELIVERY_SYSTEM = DVBT
 	FREQUENCY = 642166000
@@ -76,8 +76,8 @@
 	HIERARCHY = NONE
 	INVERSION = AUTO
 
-# R15 - Channel 28 - local channels only on Paris - Eiffel tower transmitter
-# Group Multi-7 (Canal 31, IDF1, France 24, Canal 34)
+# R15 - Channel/Canal 28 - local channels only on Paris - Eiffel tower transmitter
+# Group Multi-7 (Canal 31, 20 minutes TV, Le Figaro TV IDF)
 [CHANNEL 28]
 	DELIVERY_SYSTEM = DVBT
 	FREQUENCY = 530166000

--- a/dvb-t/fr-Paris
+++ b/dvb-t/fr-Paris
@@ -2,8 +2,8 @@
 # fr : Paris - France - differents emetteurs DVB-T de la Tour Eiffel
 # Latest update for the data / derniere mise a jour des donnees : 2025-10-10
 #
-# City                   Multiplex number : R1 R2 R4 R6 R7 R15
-# Paris - Eiffel Tower - Channel number   : 35 25 30 32 42 28
+# City                   Multiplex number : R1 R2 R4 R6 R7 R9 R15
+# Paris - Eiffel Tower - Channel number   : 35 25 30 32 42 24 28
 #
 # Note :
 # R8 - Is no longer used since the 05/04/2016 - Channel 58 is no longer used
@@ -72,6 +72,19 @@
 	CODE_RATE_LP = NONE
 	MODULATION = QAM/64
 	TRANSMISSION_MODE = 8K
+	GUARD_INTERVAL = 1/32
+	HIERARCHY = NONE
+	INVERSION = AUTO
+
+# R9 - Channel/Canal 24 - Groupe GR9A (France 2 UHD, test UHD)
+[CHANNEL 24]
+	DELIVERY_SYSTEM = DVBT2
+	FREQUENCY = 498166000
+	BANDWIDTH_HZ = 8000000
+	CODE_RATE_HP = 3/5
+	CODE_RATE_LP = NONE
+	MODULATION = QAM/256
+	TRANSMISSION_MODE = 32K
 	GUARD_INTERVAL = 1/32
 	HIERARCHY = NONE
 	INVERSION = AUTO


### PR DESCRIPTION
Update DVT scan tables for fr-Paris as of date 20/10/2025:
- removed unused multiplex R3
- update comments about channels
- add multiple R9 with UHD channels

Patch also send to linux-media@vger.kernel.org